### PR TITLE
add a test to delete a single element

### DIFF
--- a/store-test.js
+++ b/store-test.js
@@ -248,18 +248,43 @@ function basictest (settings) {
 
     })
 
-    it('should delete an element by name', function (done) {
+    it('should delete a single element by name', function (done) {
 
       var foo = si.make({ name$: 'foo' })
 
-      foo.remove$({ all$: true }, function (err, res) {
+
+      foo.list$({}, function (err, res) {
         assert.isNull(err)
+        assert.equal(3, res.length)
 
-        foo.list$({}, verify(done, function (res) {
-          assert.equal(0, res.length)
-        }))
+        foo.remove$({}, function (err, res) {
+          assert.isNull(err)
+          assert.isNotNull(res)
+          assert.equal(typeof res, 'object')
+
+          foo.list$({}, verify(done, function (res) {
+            assert.equal(2, res.length)
+          }))
+        })
       })
+    })
 
+    it('should delete all elements by name', function (done) {
+
+      var foo = si.make({ name$: 'foo' })
+      foo.list$({ }, function (err, res) {
+        assert.isNull(err)
+        assert.equal(2, res.length)
+
+        foo.remove$({ all$: true }, function (err, res) {
+          assert.isNull(err)
+          assert.isNull(res)
+
+          foo.list$({}, verify(done, function (res) {
+            assert.equal(0, res.length)
+          }))
+        })
+      })
     })
 
     it('should delete an element by property', function (done) {

--- a/store-test.js
+++ b/store-test.js
@@ -287,6 +287,29 @@ function basictest (settings) {
       })
     })
 
+    it('should not return the element if removed with load$=false', function (done) {
+
+      var foo = si.make({ name$: 'foo' })
+      foo.b = '4'
+
+      foo.save$(function (err, res) {
+        assert.isNull(err)
+        foo.list$({ }, function (err, res) {
+          assert.isNull(err)
+          assert.equal(1, res.length)
+
+          foo.remove$({load$: false}, function (err, res) {
+            assert.isNull(err)
+            assert.isNull(res)
+
+            foo.list$({}, verify(done, function (res) {
+              assert.equal(0, res.length)
+            }))
+          })
+        })
+      })
+    })
+
     it('should delete an element by property', function (done) {
 
       scratch.bar.remove$({ mark: scratch.bar.mark }, function (err, res) {


### PR DESCRIPTION
Hi,

the behavior of `remove`  is different if we remove a single or all documents, we need to check both cases